### PR TITLE
adjust media queries for references carousel to fit new logo

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -144,30 +144,30 @@ body .no-padding{
 }
 
 .carousel-inner {
-  height: 440px;
+  height: 490px;
 }
 
 @media (min-width: 576px) {
   .carousel-inner {
-    height: 440px;
+    height: 490px;
   }
 }
 
 @media (min-width: 768px) {
   .carousel-inner {
-    height: 80px;
+    height: 90px;
   }
 }
 
 @media (min-width: 992px) {
     .carousel-inner {
-      height: 123px;
+      height: 140px;
     }
 }
 
 @media (min-width: 1200px) {
     .carousel-inner {
-      height: 150px;
+      height: 170px;
     }
 }
 


### PR DESCRIPTION
The added logo was cut off on small screens because of the maximum height that prevents the "jumping" page on carousel rotation. Media queries now fit again.